### PR TITLE
Export global symbols

### DIFF
--- a/include/lz77.h
+++ b/include/lz77.h
@@ -19,8 +19,8 @@
 /** \file lz77.h
  * \brief LZ77 Depacker (to be used with Ray/TSCC packer)
  */
-#ifndef _RENDER_H
-#define _RENDER_H
+#ifndef _LZ77_H
+#define _LZ77_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,10 +39,14 @@ void *init_lz77(/** Address where to load the GPU routine. It
                 void *addr);
 
 /** Unpack LZ77 compressed data.
-    Return the size of uncompressed data. */
+	Return the size of uncompressed data. */
 int lz77_unpack(uint8_t *in, uint8_t *out);
 
+/** Asynchronous unpack LZ77 compressed data.
+	Return the size of uncompressed data. */
 int lz77_unpack_async(uint8_t *in, uint8_t *out);
+/** Wait for asynchronous unpack of LZ77 compressed data
+    to complete, triggered by the function above. */
 void lz77_unpack_wait();
 
 #ifdef __cplusplus

--- a/lz77/lz77.s
+++ b/lz77/lz77.s
@@ -161,7 +161,6 @@ _init_lz77:
 	rts
 
 	.globl	_lz77_unpack
-
 ;;; int lz77_unpack(uint8_t *in, uint8_t *out);
 _lz77_unpack:
 	move.l	depacker_addr,a0
@@ -178,6 +177,7 @@ _lz77_unpack:
 	bmi.s	.wait
 	rts
 
+	.globl	_lz77_unpack_async
 ;;; int lz77_unpack_async(uint8_t *in, uint8_t *out);
 _lz77_unpack_async:
 	move.l	depacker_addr,a0
@@ -191,6 +191,7 @@ _lz77_unpack_async:
 	move.l	(a0),d0
 	rts
 
+	.globl	_lz77_unpack_wait
 ;;; int lz77_unpack_wait:
 _lz77_unpack_wait:
 	move.l	depacker_addr,a0


### PR DESCRIPTION
In order for the linker to find the new functions, I exported these a global symbols in the assembler file.