### PR TITLE
Add missing modules, e.g. clear_screen(), clear_z_screen() etc.

### DIFF
--- a/screen/Makefile
+++ b/screen/Makefile
@@ -4,8 +4,8 @@ INCL+=-I../include
 MACFLAGS+=-i../include
 
 SRCC=a_1_buf.c a_2_buf.c a_z_buf.c n_screen.c s_1_buf.c scr2spr.c
-SRCS=cl_screen.s cl_z_screen.s
-SRCS=f_screen.s f_z_screen.s
+SRCS+=cl_screen.s cl_z_screen.s
+SRCS+=f_screen.s f_z_screen.s
 SRCS+=p_pixel.s p_pixels.s
 SRCS+=hline.s vline.s line.s
 SRCS+=scr_copy.s scr_rotate.s

--- a/screen/Makefile
+++ b/screen/Makefile
@@ -4,7 +4,7 @@ INCL+=-I../include
 MACFLAGS+=-i../include
 
 SRCC=a_1_buf.c a_2_buf.c a_z_buf.c n_screen.c s_1_buf.c scr2spr.c
-SRCS+=cl_screen.s cl_z_screen.s
+SRCS=cl_screen.s cl_z_screen.s
 SRCS+=f_screen.s f_z_screen.s
 SRCS+=p_pixel.s p_pixels.s
 SRCS+=hline.s vline.s line.s


### PR DESCRIPTION
Converting Asteroite to use new toolchain, and latest version of the Removers' library.
I noticed that clear_screen() was missing and saw that these modules were not properly added to the list of sources in the Makefile. E.g. SRCS=, instead of SRCS+=