### PR TITLE
clear_screen functions not compiling

### DIFF
--- a/screen/Makefile
+++ b/screen/Makefile
@@ -4,8 +4,7 @@ INCL+=-I../include
 MACFLAGS+=-i../include
 
 SRCC=a_1_buf.c a_2_buf.c a_z_buf.c n_screen.c s_1_buf.c scr2spr.c
-SRCS=cl_screen.s cl_z_screen.s
-SRCS=f_screen.s f_z_screen.s
+SRCS=f_screen.s f_z_screen.s cl_screen.s cl_z_screen.s
 SRCS+=p_pixel.s p_pixels.s
 SRCS+=hline.s vline.s line.s
 SRCS+=scr_copy.s scr_rotate.s


### PR DESCRIPTION
I believe the cl_screen.s and cl_z_screen.s source files are being ignored because the "SRCS" variable is being reset with the following line by f_screen.s and f_z_screen.s.  

Setting "SRCS"  with all four source files at the same time resolves the problem. 