### PR TITLE
Added Module function 'set_song_position(int position)'

### DIFF
--- a/include/sound.h
+++ b/include/sound.h
@@ -93,6 +93,10 @@ void clear_module();
 /** Play/Pause the replay of the current music */
 void pause_module();
 
+/** Set specific postiont to start playback from. */
+void set_song_position(/** Position in song to play */
+			 int position);
+
 /** Set modules voices mask. It returns the mask set. */
 int enable_module_voices(/** Mask to enable/disable voice of a
 			     module. Bit 0 = Voice 0, Bit 1 = Voice 1,

--- a/sound/protracker.s
+++ b/sound/protracker.s
@@ -30,3 +30,7 @@ _pause_module	equ	mt_pause
 ;; enable_module_voices(int mask);
 _enable_module_voices	equ	mt_enable_voices
 
+	.globl	_set_song_position
+;; set_song_position(int position);
+_set_song_position	equ	mt_SetSongPos
+

--- a/sound/pt-play.s
+++ b/sound/pt-play.s
@@ -1246,6 +1246,10 @@ mt_PositionJump:
 	MOVE.B	n_cmdlo(A6),D0
 	.endif
 	SUBQ.B	#1,D0
+	bra.s skip_SetSongPos
+mt_SetSongPos:
+	MOVE.L 4(sp),D0
+skip_SetSongPos:
 	MOVE.B	D0,mt_SongPos
 mt_pj2:	
 	CLR.B	mt_PBreakPos

--- a/sound/sound.s
+++ b/sound/sound.s
@@ -579,4 +579,8 @@ _pause_module	equ	mt_pause
 	.globl	_enable_module_voices
 ;; enable_module_voices(int mask);
 _enable_module_voices	equ	mt_enable_voices
+
+	.globl	_set_song_position
+;; set_song_position(int position);
+_set_song_position	equ	mt_SetSongPos
 	


### PR DESCRIPTION
Changes the current playback position of the song to the start of the pattern at the given song position.

Useful for:

1. Changing the point in the song as a reaction to something happening in game.  
2. Faster than having to stop and clear the currently loaded module, and then loading a new module.
3. Can potentially save space by not having to duplicate the same sample for an instrument that happens to be used in two different MOD files.  For example: If you have two songs that use the same samples, you can compose both songs inside of the same MOD file, avoiding duplicate sample data if you were to instead use two separate MOD files.